### PR TITLE
Update docs to dot-notation workbench theme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This document will tell you how to install and apply this theme on VS Code, and 
 [CHANGELOG.MD](CHANGELOG.md)
 
 # Notice
-If you want to play around with new colors, use the setting workbench.experimental.colorCustomizations to customize the currently selected theme.
+If you want to play around with new colors, use the setting workbench.colorCustomizations to customize the currently selected theme.
 You can add this snippet in your "settings.json" file   
 ```json
-"workbench.experimental.colorCustomizations":{
-  "activeTabBackground": "#282c34",
-  "activityBarBackground":"#282c34",
-  "editorGroupBackground": "#282c34",
-  "sideBarBackground": "#282c34"
+"workbench.colorCustomizations":{
+  "tab.activeBackground": "#282c34",
+  "activityBar.background": "#282c34",
+  "editorGroup.background": "#282c34",
+  "sideBar.background": "#282c34"
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,14 +145,14 @@ The following are my commonly used color:
 ![screenshot](https://raw.githubusercontent.com/Binaryify/OneDark-Pro/master/static/screenshot10.png)
 
 ## Workbench theming
-If you want to play around with new colors, use the setting workbench.experimental.colorCustomizations to customize the currently selected theme.
+If you want to play around with new colors, use the setting workbench.colorCustomizations to customize the currently selected theme.
 Your can add this snippet in your "settings.json" file   
 ```json
-"workbench.experimental.colorCustomizations":{
-  "activeTabBackground": "#282c34",
-  "activityBarBackground":"#282c34",
-  "editorGroupBackground": "#282c34",
-  "sideBarBackground": "#282c34"
+"workbench.colorCustomizations":{
+  "tab.activeBackground": "#282c34",
+  "activityBar.background": "#282c34",
+  "editorGroup.background": "#282c34",
+  "sideBar.background": "#282c34"
 }
 ```
 


### PR DESCRIPTION
Updated in VSCode version 1.12.0: https://github.com/Microsoft/vscode/commit/ff9f7b3baa6052863b55e8b6ef7c7c94d07beddf