### PR TITLE
Make JS Math constants to be in sync with Atom

### DIFF
--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -160,9 +160,16 @@
     },
     {
       "name": "math js/ts",
-      "scope": "support.constant.math,support.constant.property.math",
+      "scope": "support.constant.math",
       "settings": {
         "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#d19a66"
       }
     },
     {


### PR DESCRIPTION
Make JavaScript's Math colors to be in sync with Atom.

Atom:
![math-js-atom](https://user-images.githubusercontent.com/9781/28742951-7f74bd2c-743d-11e7-8c5e-8d57216e465b.png)

Old One Dark in VS Code:
![math-js-vs_code-old](https://user-images.githubusercontent.com/9781/28742953-942133ea-743d-11e7-8349-3f01f6d3fcae.png)

New/Updated One Dark in VS Code:
![math-js-vs_code-new](https://user-images.githubusercontent.com/9781/28742956-9f95931a-743d-11e7-8340-f0289a07293b.png)

