### PR TITLE
String Interpolation for visual grepping fixes #191

### DIFF
--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1296,6 +1296,26 @@
       "settings": {
         "foreground": "#b267e6"
       }
-    }
+    },
+    {
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#d55fde"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#aab1c0"
+			}
+		}
   ]
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1297,6 +1297,27 @@
       "settings": {
         "foreground": "#b267e6"
       }
-    }
+    },
+    {
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		}
+
   ]
 }


### PR DESCRIPTION
Adds the color purple in the brackets during string interpolation

Before
<img width="274" alt="one" src="https://user-images.githubusercontent.com/11923550/36665358-3792543a-1adf-11e8-8b28-561e3445956e.png">

After
<img width="277" alt="two" src="https://user-images.githubusercontent.com/11923550/36665374-4802c26e-1adf-11e8-8064-f358e84a6341.png">

fixes #191 