### PR TITLE
Unibody feel window

### DIFF
--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -68,7 +68,7 @@
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
     "tab.activeBackground": "#282c34",
-    "tab.border": "#181A1F",
+    "tab.border": "#528bff",
     "tab.inactiveBackground": "#21252B",
     "tab.hoverBackground": "#323842",
     "tab.unfocusedHoverBackground": "#323842",

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -67,7 +67,7 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
-    "tab.activeBackground": "#2c313a",
+    "tab.activeBackground": "#282c34",
     "tab.border": "#181A1F",
     "tab.inactiveBackground": "#21252B",
     "tab.hoverBackground": "#323842",


### PR DESCRIPTION
Hi, this is the extended version of the last pull request I made. I change a couple of colors configuration in the active background color and the border it self to be look as same as the original Atom One Dark Pro

<img width="1680" alt="screen shot 2018-06-14 at 14 11 07" src="https://user-images.githubusercontent.com/17508929/41397147-738b83a0-6fdd-11e8-953e-afaf3cefdfa1.png">
**Before**

<img width="1680" alt="screen shot 2018-06-14 at 14 10 37" src="https://user-images.githubusercontent.com/17508929/41397486-8e45d488-6fde-11e8-8098-66cec36806dd.png">
**After**

I hope you like it!