### PR TITLE
Syntax colouring changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 [GitHub repository](https://github.com/Binaryify/OneDark-Pro)
 
 # CHANGELOG
+Brief notes to what I changed - focused on ease of reading:
+- Made units (px, em.. etc) red to distinguish between the value itself and the units: easier readability
+- Made pseudo-elements/classes bluish in order to distinguish it from classes (which are the same colour in css/less/scss)
+- Made escaped characters (such as &apos; &copy; etc) red to see them easily, especially in Pug (jade) files where brackets and classes are essentially the same colour
+- The String literal in JS/TS ${} is now purply for easier readability
+- All Comments are now italic
+- Changes to TypeScript/JavaScript (possibly other languages too) syntax highlighting:
+  - Classes now all Yellow (except in TS in the case of: App.getSmth(), as both normal objects and classes use the same code inetrnally, meaning highlighting would be weird)
+  - Property names in ```js let app = { hello: "world"}``` now red, to match selector (eg: ```js app.hello ```) and themselves
+  - Optional operator ```ts ?:``` now purple too
+
 
 [CHANGELOG.MD](CHANGELOG.md)
 

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -349,7 +349,7 @@
       "name": "comment",
       "scope": "comment.line.double-slash,comment.block.documentation",
       "settings": {
-        "fontStyle": "normal"
+        "fontStyle": "italic"
       }
     },
     {
@@ -362,7 +362,7 @@
     {
       "name": "js/ts Keyword",
       "scope":
-        "keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.ternary",
+        ["keyword.operator.expression.instanceof","keyword.operator.new","keyword.operator.ternary", "keyword.operator.optional"],
       "settings": {
         "foreground": "#D55FDE"
       }
@@ -596,9 +596,9 @@
     },
     {
       "name": "Class name",
-      "scope": "entity.name.class",
+      "scope": ["entity.name.class", "variable.other.class"],
       "settings": {
-        "foreground": "#52ADF2"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -807,7 +807,7 @@
       "name": "Units",
       "scope": "keyword.other.unit",
       "settings": {
-        "foreground": "#D8985F"
+        "foreground": "#EF596F"
       }
     },
     {
@@ -1318,7 +1318,7 @@
         "punctuation.section.embedded"
       ],
       "settings": {
-        "foreground": "#d55fde"
+        "foreground": "#D55FDE"
       }
     },
     {
@@ -1350,6 +1350,34 @@
       "scope": ["support.constant.elm"],
       "settings": {
         "foreground": "#d8985fff"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#D55FDE"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#EF596F"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the samne colour",
+      "scope": ["entity.other.attribute-name.pseudo-element", "entity.other.attribute-name.pseudo-class"],
+      "settings": {
+        "foreground": "#56B6C2"
+      }
+    },
+    {
+      "name": "making property names in objects red",
+      "scope": ["string.unquoted"],
+      "settings": {
+        "foreground": "#EF596F"
       }
     }
   ]

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -350,7 +350,7 @@
       "name": "comment",
       "scope": "comment.line.double-slash,comment.block.documentation",
       "settings": {
-        "fontStyle": "normal"
+        "fontStyle": "italic"
       }
     },
     {
@@ -363,7 +363,7 @@
     {
       "name": "js/ts Keyword",
       "scope":
-        "keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.ternary",
+      ["keyword.operator.expression.instanceof","keyword.operator.new","keyword.operator.ternary", "keyword.operator.optional"],
       "settings": {
         "foreground": "#c678dd"
       }
@@ -597,9 +597,9 @@
     },
     {
       "name": "Class name",
-      "scope": "entity.name.class",
+      "scope": ["entity.name.class", "variable.other.class"],
       "settings": {
-        "foreground": "#61afef"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -808,7 +808,7 @@
       "name": "Units",
       "scope": "keyword.other.unit",
       "settings": {
-        "foreground": "#d19a66"
+        "foreground": "#e06c75"
       }
     },
     {
@@ -1351,6 +1351,34 @@
       "scope": ["support.constant.elm"],
       "settings": {
         "foreground": "#d19a66ff"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the samne colour",
+      "scope": ["entity.other.attribute-name.pseudo-element", "entity.other.attribute-name.pseudo-class"],
+      "settings": {
+        "foreground": "#56B6C2"
+      }
+    },
+    {
+      "name": "making property names in objects red",
+      "scope": ["string.unquoted"],
+      "settings": {
+        "foreground": "#e06c75"
       }
     }
   ]


### PR DESCRIPTION
Mentioned in an update to readme.md, here they are:
Brief notes to what I changed - focused on ease of reading:
- Made units (px, em.. etc) red to distinguish between the value itself and the units: easier readability
- Made pseudo-elements/classes bluish in order to distinguish it from classes (which are the same colour in css/less/scss)
- Made escaped characters (such as &apos; &copy; etc) red to see them easily, especially in Pug (jade) files where brackets and classes are essentially the same colour
- The String literal in JS/TS ${} is now purply for easier readability
- All Comments are now italic
- Changes to TypeScript/JavaScript (possibly other languages too) syntax highlighting:
  - Classes now all Yellow (except in TS in the case of: App.getSmth(), as both normal objects and classes use the same code inetrnally, meaning highlighting would be weird)
  - Property names in ```js let app = { hello: "world"}``` now red, to match selector (eg: ```js app.hello ```) and themselves
  - Optional operator ```ts ?:``` now purple too