### PR TITLE
[READY] More Improvements!

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Changes:
   - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
   - Ini (Highlighted default text so it's visible as values rather than plain text)
   - Go (Package Name highlighting)
+  - Groovy (Better function and variable highlighting)
   - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
   - Markdown (Better Lists and Links and Image highlighting)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Changes:
   - Ini (Highlighted default text so it's visible as values rather than plain text)
   - Go (Package Name highlighting)
   - Groovy (Better function and variable highlighting)
+  - HLSL (More keywords, semantics highlighted, )
   - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
   - Markdown (Better Lists and Links and Image highlighting)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Changes:
   - CSS/SCSS/LESS (Colour Operators such as * / + -)
   - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
   - Ini (Highlighted default text so it's visible as values rather than plain text)
+  - Go (Package Name highlighting)
+  - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
   - Markdown (Better Lists and Links and Image highlighting)
 
 # Docs & Contribute

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 
 # CHANGELOG
 [CHANGELOG.MD](CHANGELOG.md)
-Other Fixes:
-- Fixed PHP static variable bug
-- Fixed Units not being red
+Changes:
+- Made units red again
+- Adjusted colours of operators to be consistent, such as `++` and `--`
+- Improve some syntax highlighting for languages:
+  - Clojure
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 
 # CHANGELOG
 [CHANGELOG.MD](CHANGELOG.md)
+> Note: I (@beastdestroyer) could only make changes based on VSCode's LSP, so any changes I wished could have been made won't be able to be present until the LSPs change.
 Changes:
 - Made units red again
-- Adjusted colours of operators to be consistent, such as `++` and `--`
+- Adjusted colours of operators (+ compound operators) to be consistent, such as `++`, `--` and `*=` etc.
 - Improve some syntax highlighting for languages:
-  - Clojure (globals, symbols, vectors and constants)
+  - Clojure (globals, symbols and constants)
+  - C (certain punctuation)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Changes:
 - Improve some syntax highlighting for languages:
   - Clojure (globals, symbols and constants)
   - CSS/SCSS/LESS (Colour Operators such as * / + -)
+  - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 Changes:
 - Made units red again
 - Adjusted colours of operators (+ compound operators) to be consistent, such as `++`, `--` and `*=` etc.
+- Improve Punctuation (some)
 - Improve some syntax highlighting for languages:
   - Clojure (globals, symbols and constants)
-  - C (certain punctuation)
+  - CSS/SCSS/LESS (Colour Operators such as * / + -)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Changes:
   - Go (Package Name highlighting)
   - Groovy (Better function and variable highlighting)
   - HLSL (More keywords, semantics highlighted)
-  - R (Correct Function highlighting)
   - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
   - Markdown (Better Lists and Links and Image highlighting)
+  - R (Correct Function highlighting)
+  - SQL (Variables Highlighting, Bracketed Text Highlighting)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Changes:
   - Ini (Highlighted default text so it's visible as values rather than plain text)
   - Go (Package Name highlighting)
   - Groovy (Better function and variable highlighting)
-  - HLSL (More keywords, semantics highlighted, )
+  - HLSL (More keywords, semantics highlighted)
+  - R (Correct Function highlighting)
   - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
   - Markdown (Better Lists and Links and Image highlighting)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Changes:
   - Markdown (Better Lists and Links and Image highlighting)
   - R (Correct Function highlighting)
   - SQL (Variables Highlighting, Bracketed Text Highlighting)
+  - Swift (Type Highlighting)
+  - Visual Basic (Type Highlighting)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Changes:
   - Clojure (globals, symbols and constants)
   - CSS/SCSS/LESS (Colour Operators such as * / + -)
   - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
+  - Ini (Highlighted default text so it's visible as values rather than plain text)
   - Markdown (Better Lists and Links and Image highlighting)
 
 # Docs & Contribute

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 
 # CHANGELOG
 [CHANGELOG.MD](CHANGELOG.md)
+Other Fixes:
+- Fixed PHP static variable bug
+- Fixed Units not being red
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Changes:
 - Made units red again
 - Adjusted colours of operators to be consistent, such as `++` and `--`
 - Improve some syntax highlighting for languages:
-  - Clojure
+  - Clojure (globals, symbols, vectors and constants)
 
 # Docs & Contribute
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Changes:
   - Clojure (globals, symbols and constants)
   - CSS/SCSS/LESS (Colour Operators such as * / + -)
   - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
+  - Markdown (Better Lists and Links and Image highlighting)
 
 # Docs & Contribute
 

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -507,7 +507,7 @@
       "name": "Operators",
       "scope": "keyword.operator",
       "settings": {
-        "foreground": "#AAB1C0"
+        "foreground": "#2BBAC5"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -910,14 +910,14 @@
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown",
       "settings": {
-        "foreground": "#E06C75"
+        "foreground": "#EF596F"
       }
     },
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
       "scope": "punctuation.definition.metadata.markdown",
       "settings": {
-        "foreground": "#D55FDE"
+        "foreground": "#EF596F"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1439,6 +1439,28 @@
       "name": "Makefile text colour",
       "scope": ["source.makefile"],
       "settings": { "foreground": "#e5c07b" }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": ["storage.modifier.import.groovy"],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": ["meta.method.groovy"],
+      "settings": {
+        "foreground": "#52ADF2"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": ["meta.definition.variable.name.groovy"],
+      "settings": { "foreground": "#EF596F" }
     }
+    
+
+
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -2,7 +2,7 @@
   "name": "One Dark Pro Vivid",
   "type": "dark",
   "colors": {
-    "activityBar.background": "#21252B",
+    "activityBar.background": "#282c34",
     "activityBar.foreground": "#D7DAE0",
     "activityBarBadge.background": "#4D78CC",
     "activityBarBadge.foreground": "#F8FAFD",
@@ -911,7 +911,7 @@
       "scope": [
         "punctuation.definition.string.begin.markdown",
         "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown",
+        "punctuation.definition.metadata.markdown"
       ],
       "settings": {
         "foreground": "#EF596F"
@@ -1405,6 +1405,13 @@
       "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
       "settings": {
         "foreground": "#EF596F"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": ["source.ini"],
+      "settings": {
+        "foreground": "#98c379"
       }
     }
   ]

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1350,6 +1350,27 @@
       "settings": {
         "foreground": "#56B6C2"
       }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#EF596F"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": ["constant.keyword.clojure"],
+      "settings": {
+        "foreground": "#56B6C2"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -426,6 +426,13 @@
       }
     },
     {
+      "name": "Other punctuation .c",
+      "scope": "punctuation.separator.c",
+      "settings": {
+        "foreground": "#D55FDEff"
+      }
+    },
+    {
       "name": "C type posix-reserved",
       "scope": "support.type.posix-reserved.c",
       "settings": {
@@ -514,6 +521,13 @@
       "scope": "keyword.operator",
       "settings": {
         "foreground": "#AAB1C0"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators",
+      "scope": "keyword.operator.assignment.compound",
+      "settings": {
+        "foreground": "#D55FDEff"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -419,8 +419,8 @@
       }
     },
     {
-      "name": "C punctuation",
-      "scope": "punctuation.separator.delimiter.c",
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
       "settings": {
         "foreground": "#bbbbbb"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -274,6 +274,13 @@
       }
     },
     {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#2BBAC5"
+      }
+    },
+    {
       "name": "support.constant.property-value.scss",
       "scope": "support.constant.property-value.scss,support.constant.property-value.css",
       "settings": {
@@ -1342,6 +1349,13 @@
       }
     },
     {
+      "name": "Go package name",
+      "scope": ["entity.name.package.go"],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "elm prelude",
       "scope": ["support.type.prelude.elm"],
       "settings": {
@@ -1413,6 +1427,18 @@
       "settings": {
         "foreground": "#98c379"
       }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": ["meta.scope.prerequisites.makefile"],
+      "settings": {
+        "foreground": "#EF596F"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": ["source.makefile"],
+      "settings": { "foreground": "#e5c07b" }
     }
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -288,6 +288,13 @@
       }
     },
     {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+      "settings": {
+        "foreground": "#56B6C2"
+      }
+    },
+    {
       "name": "css color standard name",
       "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
       "settings": {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -908,7 +908,13 @@
     },
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
-      "scope": "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown",
+        "markup.list.unnumbered.markdown",
+        "markup.list.numbered.markdown"
+      ],
       "settings": {
         "foreground": "#EF596F"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -406,7 +406,7 @@
     },
     {
       "name": "keyword.operator",
-      "scope": "keyword.operator.arithmetic,keyword.operator.comparison",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
       "settings": {
         "foreground": "#2BBAC5"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -404,7 +404,13 @@
         "foreground": "#EF596F"
       }
     },
-    
+    {
+      "name": "keyword.operator",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
+      "settings": {
+        "foreground": "#2BBAC5"
+      }
+    },
     {
       "name": "C operator assignment",
       "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c",
@@ -507,14 +513,7 @@
       "name": "Operators",
       "scope": "keyword.operator",
       "settings": {
-        "foreground": "#2BBAC5"
-      }
-    },
-    {
-      "name": "keyword.operator",
-      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
-      "settings": {
-        "foreground": "#2BBAC5"
+        "foreground": "#AAB1C0"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1487,6 +1487,15 @@
         "foreground": "#D55FDE"
       }
     },
-    { "name": "SQL Variables", "scope": ["text.variable", "text.bracketed"], "settings": { "foreground": "#EF596F" } }
+    {
+      "name": "SQL Variables",
+      "scope": ["text.variable", "text.bracketed"],
+      "settings": { "foreground": "#EF596F" }
+    },
+    {
+      "name": "Types",
+      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "settings": { "foreground": "#e5c07b" }
+    }
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -413,7 +413,7 @@
     },
     {
       "name": "C operator assignment",
-      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.bitwise.shift.c",
+      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c",
       "settings": {
         "foreground": "#D55FDEff"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -912,11 +912,19 @@
         "punctuation.definition.string.begin.markdown",
         "punctuation.definition.string.end.markdown",
         "punctuation.definition.metadata.markdown",
+      ],
+      "settings": {
+        "foreground": "#EF596F"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Lists",
+      "scope": [
         "markup.list.unnumbered.markdown",
         "markup.list.numbered.markdown"
       ],
       "settings": {
-        "foreground": "#EF596F"
+        "foreground": "#98c379"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -404,13 +404,7 @@
         "foreground": "#EF596F"
       }
     },
-    {
-      "name": "keyword.operator",
-      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
-      "settings": {
-        "foreground": "#2BBAC5"
-      }
-    },
+    
     {
       "name": "C operator assignment",
       "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c",
@@ -514,6 +508,13 @@
       "scope": "keyword.operator",
       "settings": {
         "foreground": "#AAB1C0"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
+      "settings": {
+        "foreground": "#2BBAC5"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -910,7 +910,7 @@
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown",
       "settings": {
-        "foreground": "#AAB1C0"
+        "foreground": "#E06C75"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1385,6 +1385,13 @@
       "settings": {
         "foreground": "#56B6C2"
       }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.argument.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#EF596F"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1388,7 +1388,7 @@
     },
     {
       "name": "CoffeeScript Function Argument",
-      "scope": ["meta.argument.coffee", "variable.parameter.function.coffee"],
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
       "settings": {
         "foreground": "#EF596F"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1486,6 +1486,7 @@
       "settings": {
         "foreground": "#D55FDE"
       }
-    }
+    },
+    { "name": "SQL Variables", "scope": ["text.variable", "text.bracketed"], "settings": { "foreground": "#EF596F" } }
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -581,7 +581,7 @@
     },
     {
       "name": "Functions",
-      "scope": "entity.name.function, meta.require, support.function.any-method",
+      "scope": "entity.name.function, meta.require, support.function.any-method, variable.function",
       "settings": {
         "foreground": "#52ADF2"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1458,9 +1458,34 @@
       "name": "Groovy Variables",
       "scope": ["meta.definition.variable.name.groovy"],
       "settings": { "foreground": "#EF596F" }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": {
+        "foreground": "#89CA78"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#D55FDE"
+      }
     }
-    
-
-
   ]
 }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -811,7 +811,7 @@
       "name": "Units",
       "scope": "keyword.other.unit",
       "settings": {
-        "foreground": "#d8985fff"
+        "foreground": "#EF596F"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -169,13 +169,6 @@
       }
     },
     {
-      "name": "c++ control",
-      "scope": "keyword.control.cpp",
-      "settings": {
-        "foreground": "#e5c07b"
-      }
-    },
-    {
       "name": "c++ block",
       "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1354,9 +1354,7 @@
     },
     {
       "name": "Go package name",
-      "scope": [
-        "entity.name.package.go"
-      ],
+      "scope": ["entity.name.package.go"],
       "settings": {
         "foreground": "#e5c07b"
       }
@@ -1429,27 +1427,21 @@
     },
     {
       "name": "Ini Default Text",
-      "scope": [
-        "source.ini"
-      ],
+      "scope": ["source.ini"],
       "settings": {
         "foreground": "#98c379"
       }
     },
     {
       "name": "Makefile prerequisities",
-      "scope": [
-        "meta.scope.prerequisites.makefile"
-      ],
+      "scope": ["meta.scope.prerequisites.makefile"],
       "settings": {
         "foreground": "#e06c75"
       }
     },
     {
       "name": "Makefile text colour",
-      "scope": [
-        "source.makefile"
-      ],
+      "scope": ["source.makefile"],
       "settings": {
         "foreground": "#e5c07b"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -2,7 +2,7 @@
   "name": "One Dark Pro",
   "type": "dark",
   "colors": {
-    "activityBar.background": "#21252B",
+    "activityBar.background": "#282C34",
     "activityBar.foreground": "#D7DAE0",
     "activityBarBadge.background": "#4D78CC",
     "activityBarBadge.foreground": "#F8FAFD",
@@ -1409,6 +1409,15 @@
       "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
       "settings": {
         "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": [
+        "source.ini"
+      ],
+      "settings": {
+        "foreground": "#98c379"
       }
     }
   ]

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -581,7 +581,7 @@
     },
     {
       "name": "Functions",
-      "scope": "entity.name.function, meta.require, support.function.any-method",
+      "scope": ["entity.name.function", "meta.require", "support.function.any-method", "variable.function"],
       "settings": {
         "foreground": "#61afef"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -426,6 +426,13 @@
       }
     },
     {
+      "name": "Other punctuation .c",
+      "scope": "punctuation.separator.c",
+      "settings": {
+        "foreground": "#c678ddff"
+      }
+    },
+    {
       "name": "C type posix-reserved",
       "scope": "support.type.posix-reserved.c",
       "settings": {
@@ -514,6 +521,13 @@
       "scope": "keyword.operator",
       "settings": {
         "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators",
+      "scope": "keyword.operator.assignment.compound",
+      "settings": {
+        "foreground": "#c678ddff"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1392,7 +1392,7 @@
     },
     {
       "name": "CoffeeScript Function Argument",
-      "scope": ["meta.argument.coffee", "variable.parameter.function.coffee"],
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
       "settings": {
         "foreground": "#e06c75"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1361,12 +1361,21 @@
       }
     },
     {
-      "name": "Clojure symbols",
+      "name": "Clojure symbols and vectors",
       "scope": [
-        "meta.symbol.clojure"
+        "meta.symbol.clojure, meta.vector.clojure"
       ],
       "settings": {
         "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": [
+        "constant.keyword.clojure"
+      ],
+      "settings": {
+        "foreground": "#56B6C2"
       }
     }
   ]

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1363,7 +1363,7 @@
     {
       "name": "Clojure symbols and vectors",
       "scope": [
-        "meta.symbol.clojure, meta.vector.clojure"
+        "meta.symbol.clojure, eta.vector.clojure"
       ],
       "settings": {
         "foreground": "#e06c75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -419,8 +419,8 @@
       }
     },
     {
-      "name": "C punctuation",
-      "scope": "punctuation.separator.delimiter.c",
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
       "settings": {
         "foreground": "#bbbbbb"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1363,7 +1363,7 @@
     {
       "name": "Clojure symbols and vectors",
       "scope": [
-        "meta.vector.clojure"
+        "meta.symbol.clojure"
       ],
       "settings": {
         "foreground": "#e06c75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -812,7 +812,7 @@
       "name": "Units",
       "scope": "keyword.other.unit",
       "settings": {
-        "foreground": "#d19a66ff"
+        "foreground": "#E06C75"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -913,7 +913,7 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": [
-        "punctuation.definition.string.begin.markdown,punctuation.definition.metadata.markdown"
+        "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown"
       ],
       "settings": {
         "foreground": "#E06C75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1342,13 +1342,31 @@
       }
     },
     {
-      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the samne colour",
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
       "scope": [
         "entity.other.attribute-name.pseudo-element",
         "entity.other.attribute-name.pseudo-class"
       ],
       "settings": {
         "foreground": "#56B6C2"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": [
+        "entity.global.clojure"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": [
+        "meta.symbol.clojure"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
       }
     }
   ]

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1445,6 +1445,33 @@
       "settings": {
         "foreground": "#e5c07b"
       }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": [
+        "storage.modifier.import.groovy"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": [
+        "meta.method.groovy"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": [
+        "meta.definition.variable.name.groovy"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -288,6 +288,13 @@
       }
     },
     {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+      "settings": {
+        "foreground": "#56B6C2"
+      }
+    },
+    {
       "name": "css color standard name",
       "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1363,7 +1363,7 @@
     {
       "name": "Clojure symbols and vectors",
       "scope": [
-        "meta.symbol.clojure,meta.vector.clojure"
+        "meta.vector.clojure"
       ],
       "settings": {
         "foreground": "#e06c75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -406,14 +406,14 @@
     },
     {
       "name": "keyword.operator",
-      "scope": "keyword.operator.arithmetic,keyword.operator.comparison",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment",
       "settings": {
         "foreground": "#56b6c2"
       }
     },
     {
       "name": "C operator assignment",
-      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.bitwise.shift.c",
+      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c",
       "settings": {
         "foreground": "#c678ddff"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -897,7 +897,7 @@
     },
     {
       "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
-      "scope": "beginning.punctuation.definition.list.markdown",
+      "scope": "punctuation.definition.list.markdown",
       "settings": {
         "foreground": "#E06C75"
       }
@@ -913,7 +913,7 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": [
-        "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown"
+        "punctuation.definition.string.begin.markdown","punctuation.definition.string.end.markdown","punctuation.definition.metadata.markdown"
       ],
       "settings": {
         "foreground": "#E06C75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1448,29 +1448,49 @@
     },
     {
       "name": "Groovy import names",
-      "scope": [
-        "storage.modifier.import.groovy"
-      ],
+      "scope": ["storage.modifier.import.groovy"],
       "settings": {
         "foreground": "#e5c07b"
       }
     },
     {
       "name": "Groovy Methods",
-      "scope": [
-        "meta.method.groovy"
-      ],
+      "scope": ["meta.method.groovy"],
       "settings": {
         "foreground": "#61afef"
       }
     },
     {
       "name": "Groovy Variables",
-      "scope": [
-        "meta.definition.variable.name.groovy"
-      ],
+      "scope": ["meta.definition.variable.name.groovy"],
       "settings": {
         "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": { "foreground": "#98c379" }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
       }
     }
   ]

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -921,7 +921,7 @@
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
       "scope": "punctuation.definition.metadata.markdown",
       "settings": {
-        "foreground": "#C678DD"
+        "foreground": "#E06C75"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1389,6 +1389,13 @@
       "settings": {
         "foreground": "#56B6C2"
       }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.argument.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#e06c75"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -915,12 +915,20 @@
       "scope": [
         "punctuation.definition.string.begin.markdown",
         "punctuation.definition.string.end.markdown",
-        "punctuation.definition.metadata.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#E06C75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Lists",
+      "scope": [
         "markup.list.unnumbered.markdown",
         "markup.list.numbered.markdown"
       ],
       "settings": {
-        "foreground": "#E06C75"
+        "foreground": "#98c379"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1492,6 +1492,15 @@
       "settings": {
         "foreground": "#c678dd"
       }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": [
+        "text.variable", "text.bracketed"
+      ],
+      "settings": {
+        "foreground": "#E06C75"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1503,7 +1503,7 @@
       }
     },
     {
-      "name": "Swift types",
+      "name": "types",
       "scope": [
         "support.type.swift", "support.type.vb.asp"
       ],

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -912,7 +912,9 @@
     },
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
-      "scope": "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown",
+      "scope": [
+        "punctuation.definition.string.begin.markdown,punctuation.definition.metadata.markdown"
+      ],
       "settings": {
         "foreground": "#E06C75"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1363,7 +1363,7 @@
     {
       "name": "Clojure symbols and vectors",
       "scope": [
-        "meta.symbol.clojure, eta.vector.clojure"
+        "meta.symbol.clojure,meta.vector.clojure"
       ],
       "settings": {
         "foreground": "#e06c75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -588,7 +588,11 @@
     },
     {
       "name": "Class name",
-      "scope": ["entity.name.class", "variable.other.class.js","variable.other.class.ts"],
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
       "settings": {
         "foreground": "#e5c07b"
       }
@@ -1353,27 +1357,21 @@
     },
     {
       "name": "Clojure globals",
-      "scope": [
-        "entity.global.clojure"
-      ],
+      "scope": ["entity.global.clojure"],
       "settings": {
         "foreground": "#e5c07b"
       }
     },
     {
-      "name": "Clojure symbols and vectors",
-      "scope": [
-        "meta.symbol.clojure"
-      ],
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
       "settings": {
         "foreground": "#e06c75"
       }
     },
     {
       "name": "Clojure constants",
-      "scope": [
-        "constant.keyword.clojure"
-      ],
+      "scope": ["constant.keyword.clojure"],
       "settings": {
         "foreground": "#56B6C2"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -914,7 +914,7 @@
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": "punctuation.definition.string.begin.markdown,punctuation.definition.string.end.markdown,punctuation.definition.metadata.markdown",
       "settings": {
-        "foreground": "#ABB2BF"
+        "foreground": "#E06C75"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1501,6 +1501,15 @@
       "settings": {
         "foreground": "#E06C75"
       }
+    },
+    {
+      "name": "Swift types",
+      "scope": [
+        "support.type.swift", "support.type.vb.asp"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
     }
   ]
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -169,13 +169,6 @@
       }
     },
     {
-      "name": "c++ control",
-      "scope": "keyword.control.cpp",
-      "settings": {
-        "foreground": "#e5c07b"
-      }
-    },
-    {
       "name": "c++ block",
       "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -597,7 +597,7 @@
     },
     {
       "name": "Class name",
-      "scope": ["entity.name.class", "variable.other.class"],
+      "scope": ["entity.name.class", "variable.other.class.js","variable.other.class.ts"],
       "settings": {
         "foreground": "#e5c07b"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -913,7 +913,11 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
       "scope": [
-        "punctuation.definition.string.begin.markdown","punctuation.definition.string.end.markdown","punctuation.definition.metadata.markdown"
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown",
+        "markup.list.unnumbered.markdown",
+        "markup.list.numbered.markdown"
       ],
       "settings": {
         "foreground": "#E06C75"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -274,6 +274,13 @@
       }
     },
     {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
       "name": "support.constant.property-value.scss",
       "scope": "support.constant.property-value.scss,support.constant.property-value.css",
       "settings": {
@@ -1346,6 +1353,15 @@
       }
     },
     {
+      "name": "Go package name",
+      "scope": [
+        "entity.name.package.go"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "elm prelude",
       "scope": ["support.type.prelude.elm"],
       "settings": {
@@ -1418,6 +1434,24 @@
       ],
       "settings": {
         "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": [
+        "meta.scope.prerequisites.makefile"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": [
+        "source.makefile"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
       }
     }
   ]


### PR DESCRIPTION
Changes:
- Made units red again
- Adjusted colours of operators (+ compound operators) to be consistent, such as `++`, `--` and `*=` etc.
- Improve Punctuation (some)
- Improve some syntax highlighting for languages:
  - Clojure (globals, symbols and constants)
  - CSS/SCSS/LESS (Colour Operators such as * / + -)
  - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
  - Markdown (Lists, better brackets) 
Also, I didn't get through many languages (THAT WELL), VSCode's vanilla languages don't have much to customize, and some of the languages already have pretty good highlighting :)
More info available in the fork's README

## Mini To-Do List
- [x] Explore improving other languages (without their respective extensions)
  - [x] CSS
  - [x] Clojure
  - [x] CoffeeScript
  - [x] Go
  - [x] Groovy
  - [x] HLSL
  - [x] Ini
  - [x] LESS
  - [x] Makefile  
  - [x] Markdown
  - [x] R
  - [x] SCSS
  - [x] SQL
  - [x] Swift
  - [x] Visual Basic
- [x] Revert colour of sidebar to lighter variant

## Final Steps:
- [x] Checking no highlighting is broken across vanilla languages
- [x] Final Review
- [x] Ping to be ready! 