### PR TITLE
Editor Tabs Highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
+## 2.16.4
+
+- Edit editor tab highlighting to be the `#282c34` colour to be consistent across the theme
+
 ## 2.16.3 | 2018.9.09
 
--Change Separates editor styles and syntax highlighting
+- Change: Separate editor styles and syntax highlighting
 
 ## 2.16.1 | 2018.9.06
 

--- a/README.md
+++ b/README.md
@@ -8,27 +8,6 @@ Atom's iconic One Dark theme, and one of the most downloaded themes for VS Code!
 
 [CHANGELOG.MD](CHANGELOG.md)
 
-> Note: I (@beastdestroyer) could only make changes based on VSCode's LSP, so any changes I wished could have been made won't be able to be present until the LSPs change.
-> Changes:
-
-- Made units red again
-- Adjusted colours of operators (+ compound operators) to be consistent, such as `++`, `--` and `*=` etc.
-- Improve Punctuation (some)
-- Improve some syntax highlighting for languages:
-  - Clojure (globals, symbols and constants)
-  - CSS/SCSS/LESS (Colour Operators such as \* / + -)
-  - CoffeeScript (Brung some colours closer to JavaScript, for consistency)
-  - Ini (Highlighted default text so it's visible as values rather than plain text)
-  - Go (Package Name highlighting)
-  - Groovy (Better function and variable highlighting)
-  - HLSL (More keywords, semantics highlighted)
-  - Makefile (Prerequisities highlighting, text colour treated as values inputted, highlighted)
-  - Markdown (Better Lists and Links and Image highlighting)
-  - R (Correct Function highlighting)
-  - SQL (Variables Highlighting, Bracketed Text Highlighting)
-  - Swift (Type Highlighting)
-  - Visual Basic (Type Highlighting)
-
 # Docs & Contribute
 
 This document

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -67,7 +67,7 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
-    "tab.activeBackground": "#2c313a",
+    "tab.activeBackground": "#282c34",
     "tab.border": "#181A1F",
     "tab.inactiveBackground": "#21252B",
     "tab.hoverBackground": "#323842",

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -67,7 +67,7 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
-    "tab.activeBackground": "#2c313a",
+    "tab.activeBackground": "#282c34",
     "tab.border": "#181A1F",
     "tab.inactiveBackground": "#21252B",
     "tab.hoverBackground": "#323842",


### PR DESCRIPTION
This is a small polish. Within the `CHANGELOG.md` reads the following: 
> Edit editor tab highlighting to be the `#282c34` colour to be consistent across the theme

This change is self-described. It makes a tiny change which makes the hover effect more natural and looks much better with the rest of the UI. The original hover effect still exists, but the active background has been changed. I have put it under a `2.16.4` title as it cannot warrant a minor patch by itself. There are no syntax highlighting features.

@jens1o @Binaryify 