### PR TITLE
[Feature] Highlighted language variables (this, super...)

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -1215,13 +1215,6 @@ const configFactory = type => {
       }
     },
     {
-      name: 'php dollar sign',
-      scope: 'punctuation.definition.variable.php',
-      settings: {
-        foreground: colorObj['coral']
-      }
-    },
-    {
       name: 'php heredoc/nowdoc',
       scope: 'keyword.operator.heredoc.php,keyword.operator.nowdoc.php',
       settings: {

--- a/src/syntax.js
+++ b/src/syntax.js
@@ -555,6 +555,13 @@ const configFactory = type => {
       }
     },
     {
+      name: 'Language variables',
+      scope: 'variable.language',
+      settings: {
+        foreground: colorObj['chalky']
+      }
+    },
+    {
       name: 'Java Variables',
       scope: 'token.variable.parameter.java',
       settings: {

--- a/src/syntax.js
+++ b/src/syntax.js
@@ -1307,15 +1307,6 @@ const configFactory = type => {
       }
     },
     {
-      name: 'js ts this',
-      scope:
-        'var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx',
-      settings: {
-        foreground: colorObj['chalky'],
-        fontStyle: 'italic'
-      }
-    },
-    {
       name: 'ts primitive/builtin types',
       scope:
         'support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx',

--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -1336,14 +1336,6 @@
       }
     },
     {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#E5C07B",
-        "fontStyle": "italic"
-      }
-    },
-    {
       "name": "ts primitive/builtin types",
       "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
       "settings": {

--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -1245,13 +1245,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#e06c75"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {

--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -621,6 +621,13 @@
       }
     },
     {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#E5C07B"
+      }
+    },
+    {
       "name": "Java Variables",
       "scope": "token.variable.parameter.java",
       "settings": {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1215,13 +1215,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#ef596f"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -572,6 +572,13 @@
       }
     },
     {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "Java Variables",
       "scope": "token.variable.parameter.java",
       "settings": {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1306,14 +1306,6 @@
       }
     },
     {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#e5c07b",
-        "fontStyle": "italic"
-      }
-    },
-    {
       "name": "ts primitive/builtin types",
       "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -572,6 +572,13 @@
       }
     },
     {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "Java Variables",
       "scope": "token.variable.parameter.java",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1306,14 +1306,6 @@
       }
     },
     {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#e5c07b",
-        "fontStyle": "italic"
-      }
-    },
-    {
       "name": "ts primitive/builtin types",
       "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1215,13 +1215,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#e06c75"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {


### PR DESCRIPTION
Hi @Binaryify!

Thanks for this great theme! I wanted to open an issue, but I decided to improve it myself :)
This is my first pull request ever, please be indulgent.

# Motivations
As I work daily with PHP and JavaScript, I was disappointed to see ``this`` highlighted in yellow in ``.js`` files and not ``$this`` in ``.php`` ones. Alos, in PHP, ``parent`` is highlighted, but not ``super`` in JavaScript (yes, it's shown italic, but not in other languages like Java).

# Result
With my modifications, all ``variables.language`` will be highlighted in every supported languages. I tested with PHP and JavaScript of course, but also in TypeScript, JSX, C++ and Java.
All of them now have ``this``, ``super`` and all that stuff highlighted in yellow :)

You can see the result in the following screenshots:
- top left, JavaScript
- bottom left, TypeScript
- top right, Java
- bottom right, PHP

## Before
![one-dark-pro-before](https://user-images.githubusercontent.com/11503863/53683484-6fb67180-3d01-11e9-8ecc-d53333f742d4.png)

## After
![one-dark-pro-after](https://user-images.githubusercontent.com/11503863/53683485-780eac80-3d01-11e9-80ea-99988d0acb2f.png)
