### PR TITLE
[Bugfix] Fix a regression in PHP coloring

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -1222,13 +1222,6 @@ const configFactory = type => {
       }
     },
     {
-      name: 'php dollar sign',
-      scope: 'punctuation.definition.variable.php',
-      settings: {
-        foreground: colorObj['coral']
-      }
-    },
-    {
       name: 'php heredoc/nowdoc',
       scope: 'keyword.operator.heredoc.php,keyword.operator.nowdoc.php',
       settings: {
@@ -1311,15 +1304,6 @@ const configFactory = type => {
       scope: 'selector.sass',
       settings: {
         foreground: colorObj['coral']
-      }
-    },
-    {
-      name: 'js ts this',
-      scope:
-        'var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx',
-      settings: {
-        foreground: colorObj['chalky'],
-        fontStyle: 'italic'
       }
     },
     {

--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -1252,13 +1252,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#e06c75"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {
@@ -1340,14 +1333,6 @@
       "scope": "selector.sass",
       "settings": {
         "foreground": "#e06c75"
-      }
-    },
-    {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#E5C07B",
-        "fontStyle": "italic"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -1222,13 +1222,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#ef596f"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {
@@ -1310,14 +1303,6 @@
       "scope": "selector.sass",
       "settings": {
         "foreground": "#ef596f"
-      }
-    },
-    {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#e5c07b",
-        "fontStyle": "italic"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1222,13 +1222,6 @@
       }
     },
     {
-      "name": "php dollar sign",
-      "scope": "punctuation.definition.variable.php",
-      "settings": {
-        "foreground": "#e06c75"
-      }
-    },
-    {
       "name": "php heredoc/nowdoc",
       "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
       "settings": {
@@ -1310,14 +1303,6 @@
       "scope": "selector.sass",
       "settings": {
         "foreground": "#e06c75"
-      }
-    },
-    {
-      "name": "js ts this",
-      "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
-      "settings": {
-        "foreground": "#e5c07b",
-        "fontStyle": "italic"
       }
     },
     {


### PR DESCRIPTION
Hi @Binaryify!

The b5c8825 commit reintroduced some deleted lines from the pull request #287.
So in PHP, ``$this`` was bicolour (``$`` was red, ``this`` was yellow).

# Result
## Before
![one-dark-pro-before](https://user-images.githubusercontent.com/11503863/54077870-d8cc5500-42be-11e9-8321-d3e63689be65.png)

## After
![one-dark-pro-after](https://user-images.githubusercontent.com/11503863/54077871-dd910900-42be-11e9-8861-64fe15244d02.png)
