### PR TITLE
Make Rust type colors consistent with other languages

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -103,13 +103,6 @@ const configFactory = type => {
       }
     },
     {
-      name: 'entity.name.type.rust',
-      scope: 'entity.name.type.rust',
-      settings: {
-        foreground: colorObj['fountainBlue']
-      }
-    },
-    {
       name: 'entity.name.lifetime.rust',
       scope: 'entity.name.lifetime.rust',
       settings: {


### PR DESCRIPTION
Since #288 was merged, Rust types have been showing up in blue rather than in yellow. This isn't consistent with other languages - consider the following two code samples in Rust and TypeScript, which are effectively the same constructs, just with different keywords:

![Rust example](https://user-images.githubusercontent.com/784533/54868417-1ed7ed00-4d84-11e9-8211-0ae5057a348c.png)

![TypeScript example](https://user-images.githubusercontent.com/784533/54868449-77a78580-4d84-11e9-868f-092ed41801a0.png)

VS Code's Rust grammar uses the `entity.name.type.rust` scope for types - I think simply removing this rule would make it fall back to the existing definition for `entity.name.type`. That said, I'm not hugely experienced with VS Code color schemes, so it's entirely possible that I've messed this up 😅 