### PR TITLE
Add support for statusBarItem.remoteBackground

### DIFF
--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -68,6 +68,8 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
+    "statusBarItem.remoteForeground": "#f8fafd",
+    "statusBarItem.remoteBackground": "#4d78cc",
     "tab.activeBackground": "#282c34",
     "tab.border": "#181a1f",
     "tab.inactiveBackground": "#21252b",

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -68,6 +68,8 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
+    "statusBarItem.remoteForeground": "#f8fafd",
+    "statusBarItem.remoteBackground": "#4d78cc",
     "tab.activeBackground": "#282c34",
     "tab.border": "#181a1f",
     "tab.inactiveBackground": "#21252b",

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -68,6 +68,8 @@
     "statusBar.debuggingBackground": "#7e0097",
     "statusBar.debuggingBorder": "#66017a",
     "statusBar.debuggingForeground": "#ffffff",
+    "statusBarItem.remoteForeground": "#f8fafd",
+    "statusBarItem.remoteBackground": "#4d78cc",
     "tab.activeBackground": "#282c34",
     "tab.border": "#181a1f",
     "tab.inactiveBackground": "#21252b",


### PR DESCRIPTION
With the launch of [VS Code Remote Development](https://code.visualstudio.com/blogs/2019/05/02/remote-development) you can now set the foreground & background color for a remote indicator:

<img width="337" alt="image" src="https://user-images.githubusercontent.com/35271042/57100843-c6760280-6cd4-11e9-8267-ab4e577e46e5.png">

I suggest using the same colors as the `activityBarBadge`:

<img width="298" alt="image" src="https://user-images.githubusercontent.com/35271042/57100994-25d41280-6cd5-11e9-981a-2ce0884c82dd.png">