### PR TITLE
Fix java highlight

### DIFF
--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -365,7 +365,7 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,storage.type.generic.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,meta.method.body.java",
+      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
       "settings": {
         "foreground": "#abb2bf"
       }
@@ -379,7 +379,7 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "storage.modifier.import.java,storage.type.java",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
       "settings": {
         "foreground": "#E5C07B"
       }
@@ -389,6 +389,13 @@
       "scope": "meta.definition.variable.name.java",
       "settings": {
         "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#c678dd"
       }
     },
     {

--- a/themes/OneDark-Pro-bold.json
+++ b/themes/OneDark-Pro-bold.json
@@ -351,7 +351,7 @@
     },
     {
       "name": "java type",
-      "scope": "storage.type.annotation.java",
+      "scope": "storage.type.annotation.java,storage.type.object.array.java",
       "settings": {
         "foreground": "#E5C07B"
       }

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -316,7 +316,7 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,storage.type.generic.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,meta.method.body.java",
+      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
       "settings": {
         "foreground": "#abb2bf"
       }
@@ -330,9 +330,16 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "storage.modifier.import.java,storage.type.java",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
       "settings": {
         "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#c678dd"
       }
     },
     {

--- a/themes/OneDark-Pro-vivid.json
+++ b/themes/OneDark-Pro-vivid.json
@@ -302,7 +302,7 @@
     },
     {
       "name": "java type",
-      "scope": "storage.type.annotation.java",
+      "scope": "storage.type.annotation.java,storage.type.object.array.java",
       "settings": {
         "foreground": "#e5c07b"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -316,7 +316,7 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,storage.type.generic.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,meta.method.body.java",
+      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
       "settings": {
         "foreground": "#abb2bf"
       }
@@ -330,7 +330,7 @@
     },
     {
       "name": "java modifier.import",
-      "scope": "storage.modifier.import.java,storage.type.java",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
       "settings": {
         "foreground": "#e5c07b"
       }
@@ -340,6 +340,13 @@
       "scope": "meta.definition.variable.name.java",
       "settings": {
         "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#c678dd"
       }
     },
     {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -302,7 +302,7 @@
     },
     {
       "name": "java type",
-      "scope": "storage.type.annotation.java",
+      "scope": "storage.type.annotation.java,storage.type.object.array.java",
       "settings": {
         "foreground": "#e5c07b"
       }


### PR DESCRIPTION
Hello,
I have fix syntax highlighting.

The changes :
- `@` on annotation is now white (this is same in Typescript)
- `instanceof` is now highlighted
- `List<String>` is now standardized. The bracket is force to white and the type have now same color of type (this is same in Typescript)
- `ConfigurationSection[]` have now right type color

# Compare change
## OLD
![old](https://user-images.githubusercontent.com/1344792/60808040-aad12180-a187-11e9-823d-b4dc4874c3c1.png)

## NEW
![new](https://user-images.githubusercontent.com/1344792/60808054-b1f82f80-a187-11e9-97f2-b735ddca5f82.png)

