### PR TITLE
Changes constant.character.format.placeholder.other.python to whiskey…

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -575,7 +575,7 @@ const configFactory = type => {
       name: 'python placeholder reset to normal string',
       scope: 'constant.character.format.placeholder.other.python',
       settings: {
-        foreground: colorObj['green']
+        foreground: colorObj['whiskey']
       }
     },
     {


### PR DESCRIPTION
Changes constant.character.format.placeholder.other.python to whisky for better string formatting visibility in python 
Fixes #317 