### PR TITLE
Fixed convert CHANGELOG.md date format to ISO8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,26 @@
 # CHANGELOG
-## 2.27.2 | 2019.09.19
+## 2.27.2 | 2019-09-19
 - Fixed HTML highlight error
 
-## 2.27.1 | 2019.08.26
+## 2.27.1 | 2019-08-26
 - Fixed highlight error
 
-## 2.27.0 | 2019.08.22
+## 2.27.0 | 2019-08-22
 - Support Unison highlight[#326](https://github.com/Binaryify/OneDark-Pro/pull/326)
 
-## 2.26.3 | 2019.08.08
+## 2.26.3 | 2019-08-08
 - Fixed ts if/for/while statements highlight error [#325](https://github.com/Binaryify/OneDark-Pro/issues/325)
 
 - Fixed subclass highlight error [#320](https://github.com/Binaryify/OneDark-Pro/issues/320)
 
 
-## 2.26.2 | 2019.08.03
+## 2.26.2 | 2019-08-03
 - Change warning color to #d19a66 [#324](https://github.com/Binaryify/OneDark-Pro/issues/324)
 
-## 2.26.1 | 2019.08.03
+## 2.26.1 | 2019-08-03
 - Update warning Colors [#324](https://github.com/Binaryify/OneDark-Pro/issues/324)
 
-## 2.26.0 | 2019.07.11
+## 2.26.0 | 2019-07-11
 - Changes constant.character.format.placeholder.other.python to whisky for better string formatting visibility in python [#319](https://github.com/Binaryify/OneDark-Pro/pull/319)
 
 - Support Markdown underscore-style headers [#312](https://github.com/Binaryify/OneDark-Pro/issues/312)
@@ -38,56 +38,56 @@
 >Thanks for [@holdenkilbride](https://github.com/holdenkilbride)  [@orblazer](https://github.com/orblazer) [@Huxpro](https://github.com/Huxpro)
 
 
-## 2.25.3 | 2019.07.04
+## 2.25.3 | 2019-07-04
 - Fixed C++ highlight error [#313](https://github.com/Binaryify/OneDark-Pro/issues/313)
 
-## 2.25.1 | 2019.07.03
+## 2.25.1 | 2019-07-03
 - Fixed `keyof` in typescript highlight error
 
-## 2.25.0 | 2019.06.29
+## 2.25.0 | 2019-06-29
 - Improve menu foreground & active tab foreground via:[#299](https://github.com/Binaryify/OneDark-Pro/issues/299)
 
-## 2.24.1 | 2019.06.04
+## 2.24.1 | 2019-06-04
 - Improve XI language support via:[#309](https://github.com/Binaryify/OneDark-Pro/pull/309)
 
-## 2.24.0 | 2019.06.02
+## 2.24.0 | 2019-06-02
 - Add XI language support via:[#308](https://github.com/Binaryify/OneDark-Pro/pull/308)
 
-## 2.23.2 | 2019.05.27
+## 2.23.2 | 2019-05-27
 - Improve peek background color
 
-## 2.23.1 | 2019.05.24
+## 2.23.1 | 2019-05-24
 - Fix keyword delete highlight error
 
-## 2.23.0 | 2019.05.10
+## 2.23.0 | 2019-05-10
 - Improve haskell highlight
 
-## 2.22.1 | 2019.05.05
+## 2.22.1 | 2019-05-05
 - Update README.MD images
 
-## 2.22.0 | 2019.05.03
+## 2.22.0 | 2019-05-03
 - Add support for statusBarItem.remoteBackground via:[#302](https://github.com/Binaryify/OneDark-Pro/pull/302)
 
-## 2.21.0 | 2019.03.24
+## 2.21.0 | 2019-03-24
 - Make Rust type colors consistent with other languages [#298](https://github.com/Binaryify/OneDark-Pro/pull/298)
 
-## 2.20.5 | 2019.03.15
+## 2.20.5 | 2019-03-15
 - Fix two regressions in PHP coloring
 
-## 2.20.4 | 2019.03.14
+## 2.20.4 | 2019-03-14
 - Restore Python default foreground color
 
-## 2.20.2 | 2019.03.13
+## 2.20.2 | 2019-03-13
 - Improve Rust syntax
 
 - Improve default foreground color
 
 - Definitely improve Python highlight 😃
 
-## 2.19.3 | 2019.03.11
+## 2.19.3 | 2019-03-11
 - Improve Rust syntax highlight 
 
-## 2.19.2 | 2019.03.06
+## 2.19.2 | 2019-03-06
 - Improve C++, Markdown syntax highlight 
 
 ## 2.19.0
@@ -102,36 +102,36 @@
 ## 2.17.7
 - Fix border in dropdown appearing without focus
 
-## 2.17.6 | 2018.10.25
+## 2.17.6 | 2018-10-25
 - Change focus from `#F8FAFD` to `#464646` to dim the colour
 
 ## 2.17.5
 - Change focus from `#21252b` to `#F8FAFD` to improve accessibility in GUIs
 
-## 2.17.4 | 2018.10.14
+## 2.17.4 | 2018-10-14
 - Improve markdown support
 - Improve editor dropdown color
 
-## 2.17.3 | 2018.10.05
+## 2.17.3 | 2018-10-05
 - Improve elixir support #262
 - Improve flow support #222
 
-## 2.17.1 | 2018.10.04
+## 2.17.1 | 2018-10-04
 - Rewrite syntax highlight file, simplified color, update docs
 
-## 2.16.7 | 2018.10.04
+## 2.16.7 | 2018-10-04
 Imporve Ruby and FlowJS support
 
-## 2.16.6 | 2018.09.12
+## 2.16.6 | 2018-09-12
 
 - Edit editor tab highlighting to be the `#282c34` colour to be consistent across the theme
 - Improve Python italics support
 
-## 2.16.3 | 2018.9.09
+## 2.16.3 | 2018-9-09
 
 - Change: Separate editor styles and syntax highlighting
 
-## 2.16.1 | 2018.9.06
+## 2.16.1 | 2018-9-06
 
 - Made units red again
 - Adjusted colours of operators (+ compound operators) to be consistent, such as `++`, `--` and `*=` etc.
@@ -151,22 +151,22 @@ Imporve Ruby and FlowJS support
   - Swift (Type Highlighting)
   - Visual Basic (Type Highlighting)
 
-## 2.15.4 | 2018.8.09
+## 2.15.4 | 2018-08-09
 
 - Change C/C++ comments from bold to italic to make more unified #242
 
-## 2.15.3 | 2018.7.31
+## 2.15.3 | 2018-07-31
 
 - Change C/C++ comments from italic to bold
 - Fix php Static class variable highlight error
 - Fix C/C++ right shift highlight error
 
-## 2.15.1 | 2018.7.05
+## 2.15.1 | 2018-07-05
 
 - Fix css color highlight error
 - Revert changes to fix YAML unquoted strings
 
-## 2.15.0 | 2018.7.02
+## 2.15.0 | 2018-07-02
 
 - Made units (px, em.. etc) red to distinguish between the value itself and the units: easier readability
 - Made pseudo-elements/classes bluish in order to distinguish it from classes (which are the same colour in css/less/scss)
@@ -178,22 +178,22 @@ Imporve Ruby and FlowJS support
   - Property names in `js let app = { hello: "world"}` now red, to match selector (eg: `js app.hello`) and themselves
   - Optional operator `ts ?:` now purple too
 
-## 2.14.0 | 2018.6.14
+## 2.14.0 | 2018-06-14
 
 - Change terminal ansi color to match syntax color
 - Improve tab
 
-## 2.13.6 | 2018.5.17
+## 2.13.6 | 2018-05-17
 
 - Add Contributors
 
-## 2.13.5 | 2018.5.04
+## 2.13.5 | 2018-05-04
 
 - Improve go&elm highlight
 - Support Highlighted indent guides
 - Hide blue border around file explorer when focused
 
-## 2.13.4 | 2018.3.12
+## 2.13.4 | 2018-03-12
 
 - Updated `.vsixmanifest` to contain latest and correct data.
 - Updated `LICENSE` copyright date.
@@ -204,20 +204,20 @@ Imporve Ruby and FlowJS support
 - Added `galleryBanner` in `package.json` to match theme colors.
 - Revert back original terminal coloring like it was before.
 
-## 2.13.3 | 2018.3.11
+## 2.13.3 | 2018-03-11
 
 - Updated cursor color. [#189](https://github.com/Binaryify/OneDark-Pro/issues/189)
 - Removed all terminal colors. [#195](https://github.com/Binaryify/OneDark-Pro/issues/195)
 
-## 2.13.2 | 2018.3.11
+## 2.13.2 | 2018-03-11
 
 - Updated color of current active line and active line number in the editor.
 
-## 2.13.1 | 2018.3.10
+## 2.13.1 | 2018-03-10
 
 - Updated border colors for editor highlights.
 
-## 2.13.0 | 2018.3.08
+## 2.13.0 | 2018-03-08
 
 - Fixed `findMatchBackground` coloring.
 - New color for line number of the current active line in the editor.
@@ -225,19 +225,19 @@ Imporve Ruby and FlowJS support
 - New border colors for editor highlights which improves readability while searching.
 - Add some edgeSyntax syntax support
 
-## 2.12.8 | 2018.3.06
+## 2.12.8 | 2018-03-06
 
 Improve integrated terminal colors
 
-## 2.12.7 | 2018.3.05
+## 2.12.7 | 2018-03-05
 
 Update integrated terminal colors with One Dark colors
 
-## 2.12.6 | 2018.2.28
+## 2.12.6 | 2018-02-28
 
 String Interpolation for visual grepping fixes #191
 
-## 2.12.5 | 2018.2.24
+## 2.12.5 | 2018-02-24
 
 Improve bracket visibility
 
@@ -246,299 +246,299 @@ Improve line highlight background and scrollbar slider background
 Fix weird php behavior when a interface extends a PHP interface
 thanks for @nicovak @jens1o @svipben
 
-## 2.12.4 | 2018.2.11
+## 2.12.4 | 2018-02-11
 
 Improve React component tags's hightlight color
 
-## 2.12.3 | 2018.2.08
+## 2.12.3 | 2018-02-08
 
 Improve colors for Editor Tabs
 
-## 2.12.2 | 2018.1.16
+## 2.12.2 | 2018-01-16
 
 improve cursor color
 
-## 2.12.0 | 2018.1.15
+## 2.12.0 | 2018-01-15
 
 improve cursor color & selection background color
 
-## 2.11.1 | 2018.1.1
+## 2.11.1 | 2018-01-01
 
 import C# highlight color
 [#169 @ritwickdey](https://github.com/Binaryify/OneDark-Pro/issues/169) Happy
 New Year~
 
-## 2.11.0 | 2017.12.14
+## 2.11.0 | 2017-12-14
 
 Improve status bar debugging color
 
-## 2.10.23 | 2017.11.25
+## 2.10.23 | 2017-11-25
 
 Fix `use Test\ClassNameA as ClassNameAAliased;` in php
 
-## 2.10.22 | 2017.11.17
+## 2.10.22 | 2017-11-17
 
 Improve markdown inline code highlight
 
-## 2.10.21 | 2017.11.16
+## 2.10.21 | 2017-11-16
 
 Improve markdown inline code highlight
 
-## 2.10.20 | 2017.11.10
+## 2.10.20 | 2017-11-10
 
 Fix some php highlight
 
-## 2.10.19 | 2017.11.09
+## 2.10.19 | 2017-11-09
 
 Improve terminal & regexp color
 
-## 2.10.18 | 2017.11.05
+## 2.10.18 | 2017-11-05
 
 Improve terminal color
 
-## 2.10.17 | 2017.10.17
+## 2.10.17 | 2017-10-17
 
 Fix a typo in comment color code
 
-## 2.10.15 | 2017.10.07
+## 2.10.15 | 2017-10-07
 
 Improve comment highlight
 
-## 2.10.14 | 2017.10.06
+## 2.10.14 | 2017-10-06
 
 Update docs
 
-## 2.10.13 | 2017.10.05
+## 2.10.13 | 2017-10-05
 
 Changed comment to be brighter
 
-## 2.10.12 | 2017.9.23
+## 2.10.12 | 2017-09-23
 
 Add TS primitive/builtin types support in TSX
 
-## 2.10.11 | 2017.9.6
+## 2.10.11 | 2017-09-06
 
 fix Python string color inconsistency issue
 [@jens1o](https://github.com/jens1o)\
 [PR:142](https://github.com/Binaryify/OneDark-Pro/pull/142)
 
-## 2.10.10 | 2017.8.24
+## 2.10.10 | 2017-08-24
 
 Reset more styles [@jens1o](https://github.com/jens1o)\
 [PR:139](https://github.com/Binaryify/OneDark-Pro/pull/139)
 
-## 2.10.9 | 2017.8.21
+## 2.10.9 | 2017-08-21
 
 Improve diff highlight
 
-## 2.10.8 | 2017.8.12
+## 2.10.8 | 2017-08-12
 
 Improve java highlight
 
-## 2.10.7 | 2017.8.2
+## 2.10.7 | 2017-08-02
 
 Add php screenshot
 
-## 2.10.6 | 2017.7.31
+## 2.10.6 | 2017-07-31
 
 Make JS Math constants to be in sync with Atom, fix (S)CSS selectors font style
 error
 
-## 2.10.3 | 2017.7.29
+## 2.10.3 | 2017-07-29
 
 Fix php array() syntax, fix the vivid theme file path error
 
-## 2.10.0 | 2017.7.28
+## 2.10.0 | 2017-07-28
 
 Support basic markdown syntax when using vscode-todo, fix generic types in
 phpdoc, improve JavaScript constants color, add vivid theme
 
-## 2.9.8 | 2017.7.22
+## 2.9.8 | 2017-07-22
 
 Support php types in documentations
 
-## 2.9.7 | 2017.7.19
+## 2.9.7 | 2017-07-19
 
 Improve selected variable highlight
 contributor:[@bardiarastin](https://github.com/bardiarastin) on issue
 [#119](https://github.com/Binaryify/OneDark-Pro/issues/119)
 
-## 2.9.5 | 2017.7.18
+## 2.9.5 | 2017-07-18
 
 Increase the contrast of the selected text
 
-## 2.9.4 | 2017.7.15
+## 2.9.4 | 2017-07-15
 
 Reset php round bracket in method parameters
 
-## 2.9.3 | 2017.7.12
+## 2.9.3 | 2017-07-12
 
 reset php function call labels
 
-## 2.9.2 | 2017.7.11
+## 2.9.2 | 2017-07-11
 
 Improve js/ts keyword 'import' highlight
 
-## 2.9.1 | 2017.7.1
+## 2.9.1 | 2017-07-01
 
 Improve php support, fix icon format error
 
-## 2.8.9 | 2017.6.22
+## 2.8.9 | 2017-06-22
 
 Improve badge background & background color of 'Go to next error or warning'
 (Keyboard shortcut: F8) popup, add support.variable.property.process &
 debugToolBar background & support.variable.object.node support
 
-## 2.8.8 | 2017.6.20
+## 2.8.8 | 2017-06-20
 
 Improve ruler color, improve comment fontStyle, improve peek implementation
 match highlight background color
 
-## 2.8.7 | 2017.6.19
+## 2.8.7 | 2017-06-19
 
 Add jsx/tsx support, improve color of warning/error squiggles, improve ruler
 color
 
-## 2.8.6 | 2017.6.13
+## 2.8.6 | 2017-06-13
 
 Support js/ts for-of operator, support php nowdoc, support void keyword, add
 bold and italics support for Markdown
 
-## 2.8.5 | 2017.6.6
+## 2.8.5 | 2017-06-06
 
 Fix js/ts key-value separator highlight error
 
-## 2.8.4 | 2017.6.2
+## 2.8.4 | 2017-06-02
 
 Rollback for the issue [#87](https://github.com/Binaryify/OneDark-Pro/issues/87)
 
-## 2.8.3 | 2017.6.2
+## 2.8.3 | 2017-06-02
 
 improve JS/TS object-literal key highlight
 
-## 2.8.2 | 2017.6.1
+## 2.8.2 | 2017-06-01
 
 improve C highlight
 
-## 2.8.1 | 2017.5.29
+## 2.8.1 | 2017-05-29
 
 support void keyword, support ternary operators, support bitwise operators,
 support is expression in typescript
 
-## 2.8.0 | 2017.5.22
+## 2.8.0 | 2017-05-22
 
 resolve issue #48 #65 #66 #69 #70, support php comparison, add support for
 arithmetic operators, add support for php regex operators, support heredoc php
 operator
 
-## 2.7.8 | 2017.5.17
+## 2.7.8 | 2017-05-17
 
 improve block cursor contrast background color
 
-## 2.7.7 | 2017.5.16
+## 2.7.7 | 2017-05-16
 
 Fix this expand selection error, modified/added activityBar colors, added
 scrollBar colors
 
-## 2.7.5 | 2017.5.14
+## 2.7.5 | 2017-05-14
 
 Support php-parser constants, improve activity bar badge color, fix this expand
 selection error
 
-## 2.7.4 | 2017.5.11
+## 2.7.4 | 2017-05-11
 
 Few more workbench colour fixes, Update diffEditor.insertedTextBackground
 
-## 2.7.3 | 2017.5.10
+## 2.7.3 | 2017-05-10
 
 New logo and window colour additions and tweaks
 [https://github.com/Binaryify/OneDark-Pro/pull/51](https://github.com/Binaryify/OneDark-Pro/pull/51)
 
-## 2.7.2 | 2017.5.9
+## 2.7.2 | 2017-05-09
 
 add support for php's goto, update docs
 
-## 2.7.1 | 2017.5.7
+## 2.7.1 | 2017-05-07
 
 added custom colors for sidebar, statusBar, list, input boxes, etc.
 
-## 2.7.0 | 2017.5.5
+## 2.7.0 | 2017-05-05
 
 Change theme file format. Add workbench support, improve ts support, update
 document
 
-## 2.6.3 | 2017.5.2
+## 2.6.3 | 2017-05-02
 
 Make displayName and label be the same to avoid confusion, for the reason
 [https://github.com/Binaryify/OneDark-Pro/issues/41](https://github.com/Binaryify/OneDark-Pro/issues/41)
 
-## 2.6.0 | 2017.5.1
+## 2.6.0 | 2017-05-01
 
 rename to "OneDark Pro" for the reason
 [https://github.com/Binaryify/OneDark-Pro/issues/40](https://github.com/Binaryify/OneDark-Pro/issues/40)
 
-## 2.5.3 | 2017.4.24
+## 2.5.3 | 2017-04-24
 
 fix C++ heightlight error
 
-## 2.5.2 | 2017.4.21
+## 2.5.2 | 2017-04-21
 
 added support support for other class namespace outside use
 
-## 2.5.0 | 2017.4.15
+## 2.5.0 | 2017-04-15
 
 Added php function-call object and static
 
-## 2.4.16 | 2017.4.12
+## 2.4.16 | 2017-04-12
 
 improve php & C# SUPPORT
 
-## 2.4.15 | 2017.4.10
+## 2.4.15 | 2017-04-10
 
 support php constants and normalize array in double quoted strings,add keywords,
 rename
 
-## 2.4.6 | 2017.4.9
+## 2.4.6 | 2017-04-09
 
 add DOCS
 
-## 2.4.4 | 2017.4.9
+## 2.4.4 | 2017-04-09
 
 improve php support
 
-## 2.4.3 | 2017.4.8
+## 2.4.3 | 2017-04-08
 
 improve python types support & C++ support
 
-## 2.4.1 | 2017.4.8
+## 2.4.1 | 2017-04-08
 
 improve python types support
 
-## 2.4.0 | 2017.4.7
+## 2.4.0 | 2017-04-07
 
 improve python logical & variable parameter support
 
-## 2.3.9 | 2017.4.7
+## 2.3.9 | 2017-04-07
 
 improve python support
 
-## 2.3.8 | 2017.4.7
+## 2.3.8 | 2017-04-07
 
 improve document
 
-## 2.3.7 | 2017.4.7
+## 2.3.7 | 2017-04-07
 
 improve C++ support
 
-## 2.3.6 | 2017.4.6
+## 2.3.6 | 2017-04-06
 
 improve php dollar sign & logical operator height light
 
-## 2.3.5 | 2017.3.31
+## 2.3.5 | 2017-03-31
 
 improve JavaScript 'instanceof' & 'process' height light
 
-## 2.3.4 | 2017.3.29
+## 2.3.4 | 2017-03-29
 
 improve Java height light
 


### PR DESCRIPTION
Hi

Noticed you released a new version of my favorite theme! I went to check the [CHANGELOG](https://github.com/Binaryify/OneDark-Pro/blob/master/CHANGELOG.md) where I noticed you _almost_ used a ISO 8601 compliant date. 

Being the annoying person I am, I corrected it. 😄 