### PR TITLE
Remove extra comma

### DIFF
--- a/src/themes/syntax.ts
+++ b/src/themes/syntax.ts
@@ -145,7 +145,7 @@ const configFactory = configuration => {
     {
       name: 'punctuation.separator.parameters.python',
       scope:
-        'punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python,',
+        'punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python',
       settings: {
         foreground: colorObj.lightWhite
       }


### PR DESCRIPTION
I'm working on a textmate highlighting engine and the spec is a little ambiguous about a trailing comma in selectors -- there's two interpretations:
- an empty selector (matches everything)
- ignored

I'm currently implementing it as the latter, but I felt it made sense to fix this also