### PR TITLE
add syntax highlight definition for namespaces

### DIFF
--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -589,6 +589,13 @@
       }
     },
     {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "Classes",
       "scope": "entity.name.type.namespace",
       "settings": {


### PR DESCRIPTION
 fixes #412

I've chosen the same color as classes, but it should be easy to switch to another color :)