### PR TITLE
Format Elixir atoms with quotes

### DIFF
--- a/src/themes/themeData.json
+++ b/src/themes/themeData.json
@@ -2912,7 +2912,8 @@
       },
       {
         "scope": [
-          "constant.language.symbol.elixir"
+          "constant.language.symbol.elixir",
+          "constant.language.symbol.double-quoted.elixir"
         ],
         "settings": {
           "foreground": "fountainBlue"

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1809,7 +1809,8 @@
     },
     {
       "scope": [
-        "constant.language.symbol.elixir"
+        "constant.language.symbol.elixir",
+        "constant.language.symbol.double-quoted.elixir"
       ],
       "settings": {
         "foreground": "#56b6c2"


### PR DESCRIPTION
This is another portion of #464. With the latest ElixirLS update, it changed the scope name for atoms. And `:"stringy"` is a valid atom, but has a different scope so it wasnt being colored anymore either.

This adds that expected quote to match

# Current
![image](https://user-images.githubusercontent.com/11321326/101942060-25387900-3ba6-11eb-9f6f-3286e4a03ef6.png)

# Expected
![image](https://user-images.githubusercontent.com/11321326/101942082-2e294a80-3ba6-11eb-9691-b0248ec7e82c.png)

