### PR TITLE
Prevent CD run on new branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,15 +1,13 @@
 name: CD
 
-on:
-  create:
-    tag:
-      - \d+\.\d+\.\d+(\.[\w\d-]+)?
+on: create
 env: 
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
 
   deploy:
+    if: (github.event.ref_type == 'tag')
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
The `create` event is triggered by both new tags and new branches.  The workflow would be triggered and would fail when any new branch was created on GitHub.  We band-aid this by putting a condition on the deploy job, so it only runs if the thing being created is a tag.