### PR TITLE
feat: set the foreground color for the property name in CSS Preprocessor

### DIFF
--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -10,5 +10,5 @@
     "description.oneDarkPro.cancelBold": "取消设置部分代码为粗体",
     "description.oneDarkPro.setItalic": "设置部分代码为斜体",
     "description.oneDarkPro.cancelItalic": "取消设置部分代码为斜体",
-    "description.oneDarkPro.markdownStyle": "使用内置的markdown样式"
+    "description.oneDarkPro.markdownStyle": "使用内置的 Markdown 样式"
 }

--- a/themes/OneDark-Pro-flat.json
+++ b/themes/OneDark-Pro-flat.json
@@ -331,6 +331,13 @@
       }
     },
     {
+      "name": "CSS Preprocessor property-name",
+      "scope": "support.type.property-name.css",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
       "name": "js/ts module",
       "scope": "support.module.node,support.type.object.module,support.module.node",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -331,6 +331,13 @@
       }
     },
     {
+      "name": "CSS Preprocessor property-name",
+      "scope": "support.type.property-name.css",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
       "name": "js/ts module",
       "scope": "support.module.node,support.type.object.module,support.module.node",
       "settings": {


### PR DESCRIPTION
Specific changes:
1. Solved #285
2. By the way, add space between English and Chinese in the i18n file

<details>
<summary>Compare</summary>

<img width="468" alt="demo-less-before" src="https://user-images.githubusercontent.com/38807139/127738308-3b35009b-1150-4e3a-8f15-bca1e48ac651.png">
<img width="509" alt="demo-less-after" src="https://user-images.githubusercontent.com/38807139/127738311-eb5ff0fc-596c-462b-a008-b684cb0cbb19.png">
<img width="535" alt="demo-css-in-js-before" src="https://user-images.githubusercontent.com/38807139/127738316-d5fa397c-0d81-40fe-9f91-8c279beb9666.png">
<img width="552" alt="demo-css-in-js-after" src="https://user-images.githubusercontent.com/38807139/127738319-325d0bfd-ac2c-49aa-a5f3-d36db1c58325.png">

</details>