### PR TITLE
Improve Markdown and asciidoc highlighting

### DIFF
--- a/src/themes/themeData.ts
+++ b/src/themes/themeData.ts
@@ -923,7 +923,7 @@ export default {
         name: 'punctuation.definition.list.begin.markdown',
         scope: 'punctuation.definition.list.begin.markdown',
         settings: {
-          foreground: 'coral',
+          foreground: 'chalky',
         },
       },
       {
@@ -955,10 +955,17 @@ export default {
         },
       },
       {
+        name: '[VSCODE-CUSTOM] Markdown Inline Raw punctuation',
+        scope: 'punctuation.definition.raw.markdown',
+        settings: {
+          foreground: 'chalky',
+        },
+      },
+      {
         name: '[VSCODE-CUSTOM] Markdown List Punctuation Definition',
         scope: 'punctuation.definition.list.markdown',
         settings: {
-          foreground: 'coral',
+          foreground: 'chalky',
         },
       },
       {

--- a/src/themes/themeData.ts
+++ b/src/themes/themeData.ts
@@ -1010,6 +1010,41 @@ export default {
         },
       },
       {
+        "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+        "scope": "markup.raw.monospace.asciidoc",
+        "settings": {
+          "foreground": "green"
+        }
+      },
+      {
+        "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+        "scope": "punctuation.definition.asciidoc",
+        "settings": {
+          "foreground": "chalky"
+        }
+      },
+      {
+        "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+        "scope": "markup.list.asciidoc",
+        "settings": {
+          "foreground": "chalky"
+        }
+      },
+      {
+        "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+        "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+        "settings": {
+          "foreground": "purple"
+        }
+      },
+      {
+        "name": "[VSCODE-CUSTOM] Asciidoc link name",
+        "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
+        "settings": {
+          "foreground": "malibu"
+        }
+      },
+      {
         name: 'Regular Expressions',
         scope: 'string.regexp',
         settings: {

--- a/themes/OneDark-Pro-darker.json
+++ b/themes/OneDark-Pro-darker.json
@@ -883,7 +883,7 @@
       "name": "punctuation.definition.list.begin.markdown",
       "scope": "punctuation.definition.list.begin.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -915,10 +915,17 @@
       }
     },
     {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw punctuation",
+      "scope": "punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
       "scope": "punctuation.definition.list.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -958,6 +965,41 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
       "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+      "scope": "markup.raw.monospace.asciidoc",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+      "scope": "punctuation.definition.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+      "scope": "markup.list.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+      "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc link name",
+      "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
       "settings": {
         "foreground": "#61afef"
       }

--- a/themes/OneDark-Pro-flat.json
+++ b/themes/OneDark-Pro-flat.json
@@ -887,7 +887,7 @@
       "name": "punctuation.definition.list.begin.markdown",
       "scope": "punctuation.definition.list.begin.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -919,10 +919,17 @@
       }
     },
     {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw punctuation",
+      "scope": "punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
       "scope": "punctuation.definition.list.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -962,6 +969,41 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
       "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+      "scope": "markup.raw.monospace.asciidoc",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+      "scope": "punctuation.definition.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+      "scope": "markup.list.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+      "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc link name",
+      "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
       "settings": {
         "foreground": "#61afef"
       }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -883,7 +883,7 @@
       "name": "punctuation.definition.list.begin.markdown",
       "scope": "punctuation.definition.list.begin.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -915,10 +915,17 @@
       }
     },
     {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw punctuation",
+      "scope": "punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
       "scope": "punctuation.definition.list.markdown",
       "settings": {
-        "foreground": "#e06c75"
+        "foreground": "#e5c07b"
       }
     },
     {
@@ -958,6 +965,41 @@
     {
       "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
       "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+      "scope": "markup.raw.monospace.asciidoc",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+      "scope": "punctuation.definition.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+      "scope": "markup.list.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+      "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc link name",
+      "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
       "settings": {
         "foreground": "#61afef"
       }


### PR DESCRIPTION
- set raw inline string marker \` in chalky (markdown + asciidoc)
- set list (numbered | bullets) in chalky (markdown + asciidoc)
- align asciidoc raw inline string color to Markdown (green)
- align asciidoc links color to Markdown (purple) 
- align asciidoc links name color to Markdown (malibu)