### PR TITLE
Add custom color for cls token in Python

### DIFF
--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -69,6 +69,13 @@
       }
     },
     {
+      "name": "variable.parameter.function.language.special.cls.python",
+      "scope": "variable.parameter.function.language.special.cls.python",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
       "name": "storage.modifier.lifetime.rust",
       "scope": "storage.modifier.lifetime.rust",
       "settings": {


### PR DESCRIPTION
Hi guys! 
I love the theme, but I noticed that it has no support for cls token which is commonly used when working with a classmethod for example. This is what I've set up in my IDE via `settings.json` file, but wanted to share it with you.