### PR TITLE
Unify syntax highlighting for ruby string interpolation

### DIFF
--- a/themes/OneDark-Pro-darker.json
+++ b/themes/OneDark-Pro-darker.json
@@ -30,6 +30,12 @@
   },
   "tokenColors": [
     {
+      "scope": "meta.embedded",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
       "name": "unison punctuation",
       "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
       "settings": {

--- a/themes/OneDark-Pro-flat.json
+++ b/themes/OneDark-Pro-flat.json
@@ -30,6 +30,12 @@
   },
   "tokenColors": [
     {
+      "scope": "meta.embedded",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
       "name": "unison punctuation",
       "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -30,6 +30,12 @@
   },
   "tokenColors": [
     {
+      "scope": "meta.embedded",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
       "name": "unison punctuation",
       "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
       "settings": {


### PR DESCRIPTION
### Current
<img width="265" alt="image" src="https://user-images.githubusercontent.com/6327995/152581533-6c2969e8-ec21-4b71-9c19-aeabbb0da1f2.png">

`variable name(arr)` and `separator(,)` syntax highlighting does not work string interpolation.

### Expected
<img width="266" alt="image" src="https://user-images.githubusercontent.com/6327995/152582205-6326a667-457e-45a6-ac4c-fdfbbbe0bb38.png">

Compare the vscode default dark theme and try to solve. 
https://github.com/microsoft/vscode/blob/56ff566ebfea1b6f4d883c00af4978e15db29fa0/extensions/theme-defaults/themes/dark_vs.json#L26-L34
