### PR TITLE
Title Fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Atom's iconic One Dark theme, and one of the most installed [themes](https://mar
 
 
 
-[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-blue)](https://vscode.dev/theme/zhuangtongfa.Material-theme) [![Preview in vscode.dev](https://vsmarketplacebadge.apphb.com/version/zhuangtongfa.Material-theme.svg)](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme) [![Preview in vscode.dev](https://vsmarketplacebadge.apphb.com/installs/zhuangtongfa.Material-theme.svg)](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
+[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-blue)](https://vscode.dev/theme/zhuangtongfa.Material-theme) [![Version](https://vsmarketplacebadge.apphb.com/version/zhuangtongfa.Material-theme.svg)](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme) [![Installs](https://vsmarketplacebadge.apphb.com/installs/zhuangtongfa.Material-theme.svg)](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## SPONSORS
 


### PR DESCRIPTION
#700 

The badge titles in README.md had "Preview in VSCode" as title for all the badges. It is now rewritten to their respective badge names. 

**Screenshot of the fix:**

![image](https://user-images.githubusercontent.com/47941624/158091165-5cd76783-918e-4c45-a074-de37c6ec4a42.png)

