### PR TITLE
Unify Ruby symbols color

### DIFF
--- a/themes/OneDark-Pro-darker.json
+++ b/themes/OneDark-Pro-darker.json
@@ -1310,6 +1310,13 @@
       }
     },
     {
+        "name": "constant.language.symbol.hashkey.ruby",
+        "scope": "constant.language.symbol.hashkey.ruby",
+        "settings": {
+          "foreground": "#56b6c2"
+        }
+      },
+    {
       "name": "rgb-value",
       "scope": "rgb-value",
       "settings": {

--- a/themes/OneDark-Pro-flat.json
+++ b/themes/OneDark-Pro-flat.json
@@ -1313,6 +1313,13 @@
       }
     },
     {
+        "name": "constant.language.symbol.hashkey.ruby",
+        "scope": "constant.language.symbol.hashkey.ruby",
+        "settings": {
+          "foreground": "#56b6c2"
+        }
+      },
+    {
       "name": "rgb-value",
       "scope": "rgb-value",
       "settings": {

--- a/themes/OneDark-Pro-mix.json
+++ b/themes/OneDark-Pro-mix.json
@@ -1313,6 +1313,13 @@
       }
     },
     {
+        "name": "constant.language.symbol.hashkey.ruby",
+        "scope": "constant.language.symbol.hashkey.ruby",
+        "settings": {
+          "foreground": "#56b6c2"
+        }
+      },
+    {
       "name": "rgb-value",
       "scope": "rgb-value",
       "settings": {

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -1310,6 +1310,13 @@
       }
     },
     {
+        "name": "constant.language.symbol.hashkey.ruby",
+        "scope": "constant.language.symbol.hashkey.ruby",
+        "settings": {
+          "foreground": "#56b6c2"
+        }
+      },
+    {
       "name": "rgb-value",
       "scope": "rgb-value",
       "settings": {


### PR DESCRIPTION
No color was set to ruby symbols when they were hash keys. So, we had different colors for the same class of objects (symbols).

Here is the problem:
![image](https://user-images.githubusercontent.com/169211/212412217-0c49e157-68fb-49db-9907-f0340ff42113.png)

Both "first" and "second" are **symbols**, therefore they should have the same color.
