### PR TITLE
Enhancement: unify syntax highlighting of 'keyword control' for the Python language.

### DIFF
--- a/src/themes/themeData.ts
+++ b/src/themes/themeData.ts
@@ -2110,14 +2110,6 @@ export default {
         },
       },
       {
-        name: 'Python Keyword Control',
-        scope:
-          'keyword.control.import.python,keyword.control.flow.python,keyword.operator.logical.python',
-        settings: {
-          fontStyle: 'italic',
-        },
-      },
-      {
         name: 'markup.italic.markdown',
         scope: 'markup.italic.markdown',
         settings: {


### PR DESCRIPTION
In the One Dark Pro default theme, Python is the only language that has italic style on control keywords (such as “if”, “for”, etc.).

The idea is to have the same style for all languages (Python, C++, Java) to have visual uniformity and avoid confusion when using the theme in other programming languages.
