### PR TITLE
Fix issues with heading color in markdown preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,6 @@
     "semi": false
   },
   "contributes": {
-    "markdown.previewStyles": [
-      "./styles/base-inside.css",
-      "./styles/markdown-inside.css",
-      "./styles/atom-one-dark-inside.css"
-    ],
     "commands": [
       {
         "command": "oneDarkPro.showChangelog",


### PR DESCRIPTION
Re-applies the fix from
c1742ba4cc845f4e530e8d45727b55996d20aa91 that
addressed
https://github.com/Binaryify/OneDark-Pro/issues/391 It feels like there should be a more elegant
solution, but this works well enough for now