### PR TITLE
Added shadow for sticky scroll in editor and explorer sidebar

### DIFF
--- a/themes/OneDark-Pro-darker.json
+++ b/themes/OneDark-Pro-darker.json
@@ -2249,6 +2249,8 @@
     "titleBar.inactiveForeground": "#6b717d",
     "tree.indentGuidesStroke": "#ffffff1d",
     "walkThrough.embeddedEditorBackground": "#2e3440",
-    "welcomePage.buttonHoverBackground": "#404754"
+    "welcomePage.buttonHoverBackground": "#404754",
+    "editorStickyScroll.shadow": "#3e4452",
+    "sideBarStickyScroll.shadow": "#3e4452"
   }
 }

--- a/themes/OneDark-Pro-flat.json
+++ b/themes/OneDark-Pro-flat.json
@@ -2317,6 +2317,8 @@
     "tree.indentGuidesStroke": "#343a45",
     "widget.shadow": "#23252c",
     "walkThrough.embeddedEditorBackground": "#2e3440",
-    "welcomePage.buttonHoverBackground": "#404754"
+    "welcomePage.buttonHoverBackground": "#404754",
+    "editorStickyScroll.shadow": "#3e4452",
+    "sideBarStickyScroll.shadow": "#3e4452"
   }
 }

--- a/themes/OneDark-Pro-mix.json
+++ b/themes/OneDark-Pro-mix.json
@@ -2292,6 +2292,8 @@
     "titleBar.inactiveForeground": "#6b717d",
     "tree.indentGuidesStroke": "#ffffff1d",
     "walkThrough.embeddedEditorBackground": "#2e3440",
-    "welcomePage.buttonHoverBackground": "#404754"
+    "welcomePage.buttonHoverBackground": "#404754",
+    "editorStickyScroll.shadow": "#3e4452",
+    "sideBarStickyScroll.shadow": "#3e4452"
   }
 }

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -2271,6 +2271,8 @@
     "titleBar.inactiveForeground": "#6b717d",
     "tree.indentGuidesStroke": "#ffffff1d",
     "walkThrough.embeddedEditorBackground": "#2e3440",
-    "welcomePage.buttonHoverBackground": "#404754"
+    "welcomePage.buttonHoverBackground": "#404754",
+    "editorStickyScroll.shadow": "#3e4452",
+    "sideBarStickyScroll.shadow": "#3e4452"
   }
 }


### PR DESCRIPTION
The sticky scroll sections were not visible correctly.

NOTE: This is the same color as the one used for `panel.border` in each theme

Before:
<img width="1136" alt="Screenshot 2024-12-02 at 11 59 39 AM" src="https://github.com/user-attachments/assets/0d4cbf41-5d81-491e-b85c-76022fe74ad7">

After:
<img width="1136" alt="Screenshot 2024-12-02 at 11 59 00 AM" src="https://github.com/user-attachments/assets/9605380b-5a07-4d27-9206-2cb411cf84ef">
